### PR TITLE
Seção 21, Calculadora em React

### DIFF
--- a/exercicios-web/react/calculadora/src/main/Calculator.jsx
+++ b/exercicios-web/react/calculadora/src/main/Calculator.jsx
@@ -55,13 +55,15 @@ export default class Calculator extends Component {
     }
 
     addDigit(n) {
-        if (n === '.' && this.state.displayValue.includes('.')) {
+        if (n === '.' 
+                && this.state.displayValue.toString().includes('.') 
+                && this.state.values[this.state.current].toString().includes('.')) {
             return
         }
 
         const clearDisplay = this.state.displayValue === '0'
             || this.state.clearDisplay
-        const currentValue = clearDisplay ? '' : this.state.displayValue
+        const currentValue = clearDisplay ? n === '.' ? '0' : '' : this.state.displayValue
         const displayValue = currentValue + n
         this.setState({ displayValue, clearDisplay: false })
 


### PR DESCRIPTION
Olá @leonardomleitao, para esse exemplo quando digitamos no primeiro número o "." (ponto) ele não fica formatado como "0." fiz essa correção e se para o segundo número vc precisar começar com "." ele não permite, fiz essa correção tb!