### PR TITLE
compatibilidade do webpack.config.js

### DIFF
--- a/exercicios-web/bootstrap/projeto-galeria/webpack.config.js
+++ b/exercicios-web/bootstrap/projeto-galeria/webpack.config.js
@@ -28,10 +28,11 @@ module.exports = {
     },
     plugins: [
         new MiniCssExtractPlugin({ filename: 'estilo.css' }),
-        new CopyWebpackPlugin([
-            { context: 'src/', from: '**/*.html' },
-            { context: 'src/', from: 'imgs/**/*' }
-        ])
+         patterns: [
+                { context: 'src/', from: 'imgs/**/*' },
+                { context: 'src/', from: '**/*.html' },
+            ],
+        })
     ],
     module: {
         rules: [{


### PR DESCRIPTION
compatibilidade do webpack.config.js com o copy-webpack-plugin q não está funcionando na versão antiga.